### PR TITLE
Load fonts through the native library fontconfig on other (non redox) operating systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 [dependencies]
 orbclient = "0.3"
 rusttype = "0.2"
+
+[target.'cfg(not(target_os="redox"))'.dependencies]
+font-loader = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 orbclient = "0.3"
 rusttype = "0.2"
 
-[target.'cfg(not(target_os="redox"))'.dependencies]
+[target.'cfg(all(not(feature="no_std"), not(target_os = "redox")))'.dependencies]
 font-loader = "0.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,13 @@ extern crate orbclient;
 extern crate rusttype;
 
 #[cfg(not(target_os = "redox"))]
-extern crate font_loader;
+pub extern crate font_loader;
 #[cfg(not(target_os = "redox"))]
-use font_loader::system_fonts::FontPropertyBuilder;
+pub use font_loader::system_fonts::FontPropertyBuilder;
 #[cfg(not(target_os = "redox"))]
-use font_loader::system_fonts;
+pub use font_loader::system_fonts;
+#[cfg(not(target_os = "redox"))]
+pub use font_loader::system_fonts::FontProperty;
 
 use std::fs::File;
 use std::io::Read;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ impl Font {
             }
         } else { 
             // If no font matched, try again with no family, as concatenating "Sans" or "Serif" may rule out legitimate fonts
-            let mut font = Font::build_fontproperty(typeface, family, None);
+            let mut font = Font::build_fontproperty(None, family, style);
             let fonts = system_fonts::query_specific(&mut font);
             if fonts.len() >= 1 {
                 let font_data = system_fonts::get(&font);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ impl Font {
         let fonts = system_fonts::query_specific(&mut font); // Returns an empty vector if there are no matches.
         // Confirm that a font matched:
         if fonts.len() >= 1 {
-            // TODO use from_data and get to get the font
             // get the matched font straight from the data:
             let font_data = system_fonts::get(&font); // Getting font data from properties
             match font_data {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ extern crate rusttype;
 
 #[cfg(not(target_os = "redox"))]
 extern crate font_loader;
+#[cfg(not(target_os = "redox"))]
 use font_loader::system_fonts::FontPropertyBuilder;
+#[cfg(not(target_os = "redox"))]
 use font_loader::system_fonts;
 
 use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,12 @@ extern crate rusttype;
 
 #[cfg(not(target_os = "redox"))]
 extern crate font_loader;
+use font_loader::system_fonts::FontPropertyBuilder;
+use font_loader::system_fonts;
 
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use font_loader::system_fonts::FontPropertyBuilder;
-use font_loader::system_fonts;
 
 use orbclient::{Color, Renderer};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,9 @@ impl Font {
         Font::from_path(&format!("/ui/fonts/{}/{}/{}.ttf", typeface.unwrap_or("Mono"), family.unwrap_or("Fira"), style.unwrap_or("Regular")))
     }
 
+    // A funciton to automate the process of building a font property  from "typeface, family, style"
     #[cfg(not(target_os = "redox"))]
-    pub fn find(typeface: Option<&str>, family: Option<&str>, style: Option<&str>) -> Result<Font, String> {
-        // This funciton attempts to use the rust-font-loader library, a frontend
-        // to the ubiquitous C library fontconfig, to find and load the specified
-        // font. 
+    fn build_fontproperty (typeface: Option<&str>, family: Option<&str>, style: Option<&str>) -> FontProperty {
         let mut font = FontPropertyBuilder::new();
         if let Some(style) = style {
             let style_caps = &style.to_uppercase();
@@ -71,7 +69,15 @@ impl Font {
                 font = font.family(family);
             }
         }
-        let mut font = font.build();
+        font.build()
+    }
+    
+    #[cfg(not(target_os = "redox"))]
+    pub fn find(typeface: Option<&str>, family: Option<&str>, style: Option<&str>) -> Result<Font, String> {
+        // This funciton attempts to use the rust-font-loader library, a frontend
+        // to the ubiquitous C library fontconfig, to find and load the specified
+        // font. 
+        let mut font = Font::build_fontproperty(typeface, family, style);
         // font_loader::query specific returns an empty vector if there are no matches
         // and does not tag the result with associated data like "italic", merely returns
         // the name of the font if it exists.
@@ -85,9 +91,20 @@ impl Font {
                 None => Err(format!("Could not get font {} from data", &fonts[0]))
             }
         } else { 
-            // If no font matched, try to load the default font manually
-            Font::from_path("/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf")
-        } 
+            // If no font matched, try again with no family, as concatenating "Sans" or "Serif" may rule out legitimate fonts
+            let mut font = Font::build_fontproperty(typeface, family, None);
+            let fonts = system_fonts::query_specific(&mut font);
+            if fonts.len() >= 1 {
+                let font_data = system_fonts::get(&font);
+                match font_data {
+                    Some((data, _)) => Ok(Font::from_data(data.into_boxed_slice())?),
+                    None => Err(format!("Could not get font {} from data", &fonts[0]))
+                }
+            }  else {
+                // If no font matched, try to load the default font manually
+                Font::from_path("/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf")
+            }
+        }
     }
 
     /// Load a font from file path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,17 @@ impl Font {
             }
         }
         if let Some(family) = family {
-            font = font.family(family);
+            if let Some(typeface) = typeface {
+                let typeface_caps = &typeface.to_uppercase();
+                // manually adding Serif and Sans
+                if typeface_caps.contains("SERIF") {
+                    font = font.family(&[family, "Serif"].concat());
+                } else if typeface_caps.contains("SANS") {
+                    font = font.family(&[family, "Sans"].concat())
+                }
+            } else {
+                font = font.family(family);
+            }
         }
         let mut font = font.build();
         // font_loader::query specific returns an empty vector if there are no matches


### PR DESCRIPTION
Orbfont::find() did not find anything on my system, so I tacked on [rust-font-loader](https://github.com/MSleepyPanda/rust-font-loader), a rust front-end for fontconfig, which is a C library that is installed on most Linux computers.

# Pros:

- orbfont::find() now works on my computer: ![Running fine](http://i.imgur.com/HhPW3ZY.jpg)

- Wikipedia tells me fontconfig can be installed on Mac OS and Windows, which rust-font-loader claims to support

- Compiles for redox and linux on my computer

# Cons:

- rust-font-loader isn't 1:1 in representation of fonts with the typeface, family, style thing: instead, the only typeface that can be specified is monospace, ~~so specifying sans or serif won't change anything~~

- EDIT: It seems to work if I just append "serif" or "sans" to the end of the name of the family that rust-font-loader is looking for, so I changed it to that. Now both the non-redox and redox orbfont appear to be able to use functions like `orbfont::(Some("Serif"), Some("Liberation"), Some("Regular"))`, even though the regular argument will just be ignored on non-redox

- It wraps a c library (which is probably unsafe), and adds an extra dependency. If you don't want to merge it because adding another dependency pollutes such a small and pristine library, I understand 

- It's kinda messy. If you can think of a way to clean up this code, please tell me before merging it